### PR TITLE
add token_namespace option to provider for use if different from targeted namespace

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -85,7 +85,7 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("VAULT_NAMESPACE", ""),
 				Description: "The namespace to use. Available only for Vault Enterprise",
 			},
-			"token-namespace": {
+			"token_namespace": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The namespace where the provided vault token was created, if different from the value in 'namespace'",
@@ -226,8 +226,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, errors.New("no vault token found")
 	}
 
-	// if 'token-namespace' provided, set client namespace to use it for child token creation, else use 'namespace'
-	tokenNamespace := d.Get("token-namespace").(string)
+	// if 'token_namespace' provided, set client namespace to use it for child token creation, else use 'namespace'
+	tokenNamespace := d.Get("token_namespace").(string)
 	namespace := d.Get("namespace").(string)
 	if tokenNamespace != "" {
 		client.SetNamespace(tokenNamespace)

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -226,14 +226,13 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, errors.New("no vault token found")
 	}
 
+	// if 'token-namespace' provided, set client namespace to use it for child token creation, else use 'namespace'
 	tokenNamespace := d.Get("token-namespace").(string)
+	namespace := d.Get("namespace").(string)
 	if tokenNamespace != "" {
 		client.SetNamespace(tokenNamespace)
 	} else {
-		namespace := d.Get("namespace").(string)
-		if namespace != "" {
-			client.SetNamespace(namespace)
-		}
+		client.SetNamespace(namespace)
 	}
 
 	// In order to enforce our relatively-short lease TTL, we derive a
@@ -267,6 +266,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	log.Printf("[INFO] Using Vault token with the following policies: %s", strings.Join(policies, ", "))
 
 	client.SetToken(childToken)
+	client.SetNamespace(namespace)
 
 	return client, nil
 }

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -85,6 +85,11 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("VAULT_NAMESPACE", ""),
 				Description: "The namespace to use. Available only for Vault Enterprise",
 			},
+			"token-namespace": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The namespace where the provided vault token was created, if different from the value in 'namespace'",
+			},
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -221,9 +226,14 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, errors.New("no vault token found")
 	}
 
-	namespace := d.Get("namespace").(string)
-	if namespace != "" {
-		client.SetNamespace(namespace)
+	tokenNamespace := d.Get("token-namespace").(string)
+	if tokenNamespace != "" {
+		client.SetNamespace(tokenNamespace)
+	} else {
+		namespace := d.Get("namespace").(string)
+		if namespace != "" {
+			client.SetNamespace(namespace)
+		}
 	}
 
 	// In order to enforce our relatively-short lease TTL, we derive a


### PR DESCRIPTION
### Description
Add configuration option to provider when the used Vault token was originally created in a different namespace than the namespace provided in the 'namespace' configuration option
This is required for the child token to be created in the same namespace as the parent token (which is required for the correct policies to be used by the child token)


### Testing
```
tested w/ a token that has namespace_path of <parent-namespace>/
terraform config has namespace set to <parent-namespace>/<child-namespace> & token_namespace set to <parent-namespace> & a token created in <parent-namespace>
terraform plan gives me a valid output & not a 403 like it used to before this change
```